### PR TITLE
Handle windows with no _NET_WM_WINDOW_TYPE property

### DIFF
--- a/azulejo/Window.py
+++ b/azulejo/Window.py
@@ -37,7 +37,10 @@ class Window:
         return self.get_property_value("_NET_WM_DESKTOP")[0]
     
     def get_window_type(self):
-        return self.get_property_value("_NET_WM_WINDOW_TYPE")[0]
+        return (self.get_property_value("_NET_WM_WINDOW_TYPE") or [None])[0]
+
+    def get_transient_for(self):
+        return self.get_property_value("WM_TRANSIENT_FOR")
         
     def get_property_value(self, name):
         propt = self.XWindow.get_full_property(self.__display.intern_atom(name), X.AnyPropertyType)

--- a/azulejo/WindowFetcher.py
+++ b/azulejo/WindowFetcher.py
@@ -50,7 +50,9 @@ class WindowFetcher(object):
     @staticmethod      
     def window_is_window_type_normal(window):
         assert isinstance(window, Window)
-        if window.get_window_type() == Workarea.atom("_NET_WM_WINDOW_TYPE_NORMAL"):
+        window_type = window.get_window_type()
+        if (window_type == Workarea.atom("_NET_WM_WINDOW_TYPE_NORMAL")
+            or (window_type is None and window.get_transient_for() is None)):
                 return True
         return False
 


### PR DESCRIPTION
If the _NET_WM_WINDOW_TYPE property is not set for a window (like
URxvt), get_window_type() fails. Handle those windows as normal if they
don't have the WM_TRANSIENT_FOR property set. This is specified in the
Extended Window Manager Hints (EWMH) spec as follows:

  _NET_WM_WINDOW_TYPE_NORMAL indicates that this is a normal, top-level
  window, either managed or override-redirect. Managed windows with
  neither _NET_WM_WINDOW_TYPE nor WM_TRANSIENT_FOR set MUST be taken as
  this type.

  http://standards.freedesktop.org/wm-spec/latest/ar01s05.html

This change fixes the handling of rxvt-unicode windows.
