### PR TITLE
setup.py: Specify install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 from setuptools import setup
 
-
-#see http://pypi.python.org/pypi/stdeb for package building instructions
-#or else here: https://github.com/astraw/stdeb
+# See http://pypi.python.org/pypi/stdeb for package building instructions
+# or else here: https://github.com/astraw/stdeb
 
 setup(name='azulejo',
       version='0.1',

--- a/setup.py
+++ b/setup.py
@@ -14,4 +14,5 @@ setup(name='azulejo',
       },
       include_package_data=True,
       scripts=['bin/azulejo'],
+      install_requires=['pygobject', 'python-xlib', 'notify2'],
       )


### PR DESCRIPTION
`setup.py` is missing install requirements. These are the ones that are correct on my system (Fedora 23).